### PR TITLE
feat: improved typing for trace function

### DIFF
--- a/src/cookbook/tracing_with_images_open_ai.ts
+++ b/src/cookbook/tracing_with_images_open_ai.ts
@@ -42,6 +42,9 @@ const askVision = trace('askVision', async (image_url: string): Promise<string |
 
 const imageChain = trace('imageChain', async (query: string) => {
   const image_url = await imageMaker(query);
+  if (!image_url) {
+    return null;
+  }
   return await askVision(image_url);
 });
 


### PR DESCRIPTION
Currently the `trace` function is typed as `any` for its parameters, meaning you lose type safety. This change should preserve the parameter types of whatever callback is passed in. 